### PR TITLE
Fix error while deploying on heroku

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,6 @@
     "name": "frenchfrogs/framework",
     "description": "Usefull class for FrenchFrogs",
     "type": "library",
-    "source": {
-        "url": "git@github.com:FrenchFrogs/framework.git",
-        "type": "git",
-        "reference": "origin/master"
-    },
     "keywords": ["laravel", "french", "frogs", "datagrid", "datatable", "framework", "bootstrap", "table", "form", "plugins"],
     "homepage": "https://github.com/FrenchFrogs/framework",
     "licence": "GPL-3.0+",


### PR DESCRIPTION
Fix this error:

```
- Installing frenchfrogs/framework (1.9)
           Downloading: Failed
           Failed to download frenchfrogs/framework from dist: The "https://api.github.com/repos/FrenchFrogs/framework/zipball/origin/master" file could not be downloaded (HTTP/1.1 302 Found)
           Now trying to download from source
         - Installing frenchfrogs/framework (1.9)
           Cloning ce41eb646e4eb2e317bc22adb748f2c94423fca9

```
